### PR TITLE
크롬 v.27 에서 BBS Select List Change 이벤트 수정

### DIFF
--- a/src/main/webapp/js/okjsp.js
+++ b/src/main/webapp/js/okjsp.js
@@ -96,6 +96,9 @@ function errImage(n) {
 }
 
 function jumpto(e) {
+	if (e.value === "") {
+		return false;
+	}
 	saveBbslist("bbslist", e.value);
 	document.location.href='/bbs?act=LIST&bbs='+e.value;
 }


### PR DESCRIPTION
BBS 셀렉트 박스 (스크롤) 변경할 때, 파라미터 값이 없는 경우,
Location.href 하지 않도록 변경함 - 크롬 V27 대응
